### PR TITLE
Added an example for hostname

### DIFF
--- a/app/src/main/java/com/twilio/android/quickstart/RegistrationIntentService.java
+++ b/app/src/main/java/com/twilio/android/quickstart/RegistrationIntentService.java
@@ -42,7 +42,7 @@ public class RegistrationIntentService extends IntentService {
     private static final String TAG = "RegIntentService";
     private BindingResource bindingResource;
     private static final String schema = "http";
-    private static final String host = "YOUR-SERVER-HOST-NAME";
+    private static final String host = "myserver.com";
     private static final int port = 80;
 
     public RegistrationIntentService() {

--- a/app/src/main/java/com/twilio/android/quickstart/RegistrationIntentService.java
+++ b/app/src/main/java/com/twilio/android/quickstart/RegistrationIntentService.java
@@ -42,7 +42,7 @@ public class RegistrationIntentService extends IntentService {
     private static final String TAG = "RegIntentService";
     private BindingResource bindingResource;
     private static final String schema = "http";
-    private static final String host = "myserver.com";
+    private static final String host = "myserver.com"; //Do NOT include http://
     private static final int port = 80;
 
     public RegistrationIntentService() {


### PR DESCRIPTION
Often people include http:// in the hostname that makes the request fail. Providing an example without http:// helps avoid that.