### PR TITLE
Correct AndroidManifest.xml firebase event

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,10 +18,9 @@
         <!-- [END fcm_listener] -->
         <!-- [START instanceId_listener] -->
         <service
-            android:name="com.twilio.notify.quickstart.fcm.NotifyFirebaseInstanceIDService"
-            android:exported="false">
+            android:name="com.twilio.notify.quickstart.fcm.NotifyFirebaseInstanceIDService">
             <intent-filter>
-                <action android:name="com.google.android.gms.iid.InstanceID" />
+                <action android:name="com.google.firebase.INSTANCE_ID_EVENT" />
             </intent-filter>
         </service>
         <!-- [END instanceId_listener] -->

--- a/app/src/main/java/com/twilio/notify/quickstart/BindingIntentService.java
+++ b/app/src/main/java/com/twilio/notify/quickstart/BindingIntentService.java
@@ -49,10 +49,18 @@ public class BindingIntentService extends IntentService {
         String identity = sharedPreferences.getString(IDENTITY, null);
         String address = sharedPreferences.getString(ADDRESS, null);
 
-
         if (newIdentity == null) {
             // If no identity was provided to us then we use the identity stored in shared preferences.
-            newIdentity = identity;
+            if (identity != null) {
+                newIdentity = identity;
+            } else {
+                /*
+                 * When the application is first installed refreshToken() may be called without the
+                 * user providing an identity. In this case we ignore the request to bind.
+                 */
+                Log.w(TAG, "No identity was provided.");
+                return;
+            }
         }
 
         String endpoint = sharedPreferences.getString(ENDPOINT + newIdentity, null);

--- a/app/src/main/java/com/twilio/notify/quickstart/BindingIntentService.java
+++ b/app/src/main/java/com/twilio/notify/quickstart/BindingIntentService.java
@@ -55,7 +55,7 @@ public class BindingIntentService extends IntentService {
                 newIdentity = identity;
             } else {
                 /*
-                 * When the application is first installed refreshToken() may be called without the
+                 * When the application is first installed onTokenRefresh() may be called without the
                  * user providing an identity. In this case we ignore the request to bind.
                  */
                 Log.w(TAG, "No identity was provided.");


### PR DESCRIPTION
I found this bug working on my integration with the Video SDK and Notify. Turns out the AndroidManifest.xml was out of date and was not propagating the `onTokenRefresh()` event.